### PR TITLE
Fix documentation example syntax error

### DIFF
--- a/docs/python-eg.rst
+++ b/docs/python-eg.rst
@@ -110,7 +110,7 @@ of works whose DOI appears in the attached database named
    crossref_instance.populate(
        "selected-works.db",
        condition="EXISTS (SELECT 1 FROM attached.selected_dois WHERE works.doi = selected_dois.doi)",
-       ["attached:selected.db"]
+       attach_databases=["attached:selected.db"]
    )
 
 Populate the database from ORCID


### PR DESCRIPTION
In the documentation example `Record selection from external database`, the argument `["attached:selected.db"]` was passed as a positional argument after the keyword argument `condition`, which caused a SyntaxError when running the code. To fix the issue, I added the key of the `attach_databases` parameter to the argument list. This ensures that the argument is correctly associated with the corresponding parameter in the function signature.