### PR TITLE
Add split point of db_spec and fix typo

### DIFF
--- a/src/alexandria3k/data_source.py
+++ b/src/alexandria3k/data_source.py
@@ -328,7 +328,7 @@ class DataSource:
             attach_databases = []
         for db_spec in attach_databases:
             try:
-                (db_name, db_path) = db_spec.split(":")
+                (db_name, db_path) = db_spec.split(":", 1)
             except ValueError:
                 fail(
                     f"Invalid database specification: '{db_spec}'; expected name:path"
@@ -537,7 +537,7 @@ class DataSource:
             tables in the database being populated prefixed by `populated`.
             Implicitly, if a main table is populated, its details tables
             will only get populated with the records associated with the
-            correspoing main table's record.
+            corresponding main table's record.
         :type condition: str, optional
 
 


### PR DESCRIPTION
Add the exact point of splitting of the db_spec string. Over the testing process on Windows machine the string of db_spec contains two colons. That way the path to the temporary attached database is similar to "C://..." and the splitting operation ends up giving three strings[db_name. 'C', and the rest], thus it returns a destroyed path to the attached database. Putting the regulation of spitting on the first colon focuses on taking firstly the db_name and the rest should be the path.

Fix typo of word corresponding.