### PR TITLE
Add USPTO sampling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -19,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pipenv
+          pip install pipenv==2023.7.23
           cd src && pipenv install --dev
       - name: Run unit and integration tests
         run: cd src && pipenv run python -m unittest discover -s ..

--- a/src/alexandria3k/__main__.py
+++ b/src/alexandria3k/__main__.py
@@ -86,8 +86,13 @@ def get_data_source_instance(args):
             "The data source {facility} requires the specification of a data location"
         )
 
+    # The sampling expression defaults to True or it can be
+    # given via the CI. One can manipulate the sampling function
+    # by using a variable called data as the input argument
+    # of the lambda function to access the input of the callable.
+    # (e.g. For USPTO sampling the input of the callable is a tuple)
     # pylint: disable-next=eval-used
-    sample = eval(f"lambda path: {args.sample}")
+    sample = eval(f"lambda data: {args.sample}")
 
     class_ = module_get_attribute(module, class_name(facility))
     return class_(data_location, sample, args.attach_databases)
@@ -156,10 +161,11 @@ def add_subcommand_populate(subparsers):
     parser.add_argument(
         "-s",
         "--sample",
-        # By default the function always returns True
         default="True",
         type=str,
-        help="Python expression to sample the Crossref tables (e.g. random.random() < 0.0002)",
+        help="Python expression to sample the data (e.g. random.random() < 0.0002). "
+        + "The expression can also use a variable named data whose value is documented "
+        + "in the constructor API of each data source.",
     )
 
 
@@ -294,10 +300,11 @@ def add_subcommand_query(subparsers):
     parser.add_argument(
         "-s",
         "--sample",
-        # By default the function always returns True
         default="True",
         type=str,
-        help="Python expression to sample the Crossref tables (e.g. random.random() < 0.0002)",
+        help="Python expression to sample the data (e.g. random.random() < 0.0002). "
+        + "The expression can also use a variable named data whose value is documented "
+        + "in the constructor API of each data source.",
     )
 
 

--- a/tests/data_sources/test_uspto.py
+++ b/tests/data_sources/test_uspto.py
@@ -35,9 +35,7 @@ from alexandria3k import debug
 
 
 DATABASE_PATH = td("tmp/uspto.db")
-ATTACHED_DATABASE_PATH = (
-    "C:/Users/junio/Desktop/alexandria3k-3/tests/tmp/attached_uspto.db"
-)
+ATTACHED_DATABASE_PATH = td("tmp/attached_uspto.db")
 
 
 def populate_attached():
@@ -58,9 +56,7 @@ class TestUsptoPopulateVanilla(PopulateQueries):
 
         FileCache.parse_counter = 0
         UsptoZipCache.file_reads = 0
-        cls.uspto = uspto.Uspto(
-            td("data/April 2023 Patent Grant Bibliographic Data")
-        )
+        cls.uspto = uspto.Uspto(td("data/April 2023 Patent Grant Bibliographic Data"))
         cls.uspto.populate(DATABASE_PATH)
         cls.con = sqlite3.connect(DATABASE_PATH)
         cls.cursor = cls.con.cursor()
@@ -122,9 +118,7 @@ class TestUsptoPopulateVanilla(PopulateQueries):
             12,
         )
 
-        self.assertEqual(
-            self.cond_count("us_patents", "series_code = '17'"), 3
-        )
+        self.assertEqual(self.cond_count("us_patents", "series_code = '17'"), 3)
         self.assertEqual(FileCache.parse_counter, 14)
 
 
@@ -137,9 +131,7 @@ class TestUsptoPopulateMasterCondition(PopulateQueries):
         debug.set_flags(["sql", "dump-matched"])
 
         FileCache.parse_counter = 0
-        cls.uspto = uspto.Uspto(
-            td("data/April 2023 Patent Grant Bibliographic Data")
-        )
+        cls.uspto = uspto.Uspto(td("data/April 2023 Patent Grant Bibliographic Data"))
         cls.uspto.populate(DATABASE_PATH, None, "type = 'plant'")
         cls.con = sqlite3.connect(DATABASE_PATH)
         cls.cursor = cls.con.cursor()
@@ -162,12 +154,8 @@ class TestUsptoPopulateDetailCondition(PopulateQueries):
         FileCache.parse_counter = 0
         # debug.set_flags(["sql", "dump-matched"])
 
-        cls.uspto = uspto.Uspto(
-            td("data/April 2023 Patent Grant Bibliographic Data")
-        )
-        cls.uspto.populate(
-            DATABASE_PATH, None, "icpr_classifications.subclass = 'G'"
-        )
+        cls.uspto = uspto.Uspto(td("data/April 2023 Patent Grant Bibliographic Data"))
+        cls.uspto.populate(DATABASE_PATH, None, "icpr_classifications.subclass = 'G'")
         cls.con = sqlite3.connect(DATABASE_PATH)
         cls.cursor = cls.con.cursor()
 
@@ -197,9 +185,7 @@ class TestUsptoPopulateMasterColumnNoCondition(PopulateQueries):
         FileCache.parse_counter = 0
 
         # debug.set_flags(["sql"])
-        cls.uspto = uspto.Uspto(
-            td("data/April 2023 Patent Grant Bibliographic Data")
-        )
+        cls.uspto = uspto.Uspto(td("data/April 2023 Patent Grant Bibliographic Data"))
         cls.uspto.populate(DATABASE_PATH, ["us_patents.type"])
         cls.con = sqlite3.connect(DATABASE_PATH)
         cls.cursor = cls.con.cursor()
@@ -231,9 +217,7 @@ class TestUsptoPopulateMasterColumnCondition(PopulateQueries):
         FileCache.parse_counter = 0
 
         debug.set_flags(["sql"])
-        cls.uspto = uspto.Uspto(
-            td("data/April 2023 Patent Grant Bibliographic Data")
-        )
+        cls.uspto = uspto.Uspto(td("data/April 2023 Patent Grant Bibliographic Data"))
         cls.uspto.populate(
             DATABASE_PATH,
             ["us_patents.drawings_number"],
@@ -269,9 +253,7 @@ class TestUsptoPopulateDetailConditionColumn(PopulateQueries):
         FileCache.parse_counter = 0
 
         debug.set_flags(["sql"])
-        cls.uspto = uspto.Uspto(
-            td("data/April 2023 Patent Grant Bibliographic Data")
-        )
+        cls.uspto = uspto.Uspto(td("data/April 2023 Patent Grant Bibliographic Data"))
         cls.uspto.populate(
             DATABASE_PATH,
             ["us_patents.drawings_number", "icpr_classifications.*"],
@@ -304,9 +286,7 @@ class TestUsptoPopulateMultipleConditionColumn(PopulateQueries):
         FileCache.parse_counter = 0
 
         debug.set_flags(["sql"])
-        cls.uspto = uspto.Uspto(
-            td("data/April 2023 Patent Grant Bibliographic Data")
-        )
+        cls.uspto = uspto.Uspto(td("data/April 2023 Patent Grant Bibliographic Data"))
         cls.uspto.populate(
             DATABASE_PATH,
             ["us_patents.figures_number"],
@@ -389,9 +369,7 @@ class TestUsptoQuery(unittest.TestCase):
     def test_patents(self):
         for partition in True, False:
             self.assertEqual(
-                record_count(
-                    self.uspto.query("SELECT * FROM us_patents", partition)
-                ),
+                record_count(self.uspto.query("SELECT * FROM us_patents", partition)),
                 14,
             )
         self.assertEqual(FileCache.parse_counter, 28)
@@ -427,9 +405,7 @@ class TestUsptoQuery(unittest.TestCase):
         for partition in True, False:
             self.assertEqual(
                 record_count(
-                    self.uspto.query(
-                        "SELECT * FROM icpr_classifications", partition
-                    )
+                    self.uspto.query("SELECT * FROM icpr_classifications", partition)
                 ),
                 30,
             )
@@ -437,11 +413,11 @@ class TestUsptoQuery(unittest.TestCase):
         FileCache.parse_counter = 0
 
     def test_patents_claims_condition(self):
-        for partition in True, False:
+        for partition in False, True:
             self.assertEqual(
                 record_count(
                     self.uspto.query(
-                        "SELECT us_patents.claims_number FROM us_patents LEFT JOIN"
+                        "SELECT us_patents.language FROM us_patents INNER JOIN"
                         + " icpr_classifications ON us_patents.container_id = "
                         + " icpr_classifications.patent_id WHERE us_patents.type = 'utility'"
                         + " AND icpr_classifications.symbol_position = 'F'",
@@ -453,12 +429,12 @@ class TestUsptoQuery(unittest.TestCase):
         FileCache.parse_counter = 0
 
     def test_patents_column_subset_condition(self):
-        for partition in True, False:
+        for partition in False, True:
             self.assertEqual(
                 record_count(
                     self.uspto.query(
-                        "SELECT us_patents.claims_number, icpr_classifications.main_group "
-                        + "FROM us_patents LEFT JOIN icpr_classifications ON us_patents."
+                        "SELECT us_patents.claims_number,  icpr_classifications.main_group "
+                        + "FROM us_patents INNER JOIN icpr_classifications ON us_patents."
                         + "container_id = icpr_classifications.patent_id WHERE us_patents.type"
                         + " = 'utility' AND icpr_classifications.symbol_position = 'L'",
                         partition,
@@ -500,3 +476,40 @@ class TestUsptoPopulateAttachedDatabaseCondition(PopulateQueries):
     def test_counts(self):
         self.assertEqual(self.record_count("us_patents"), 4)
         self.assertEqual(FileCache.parse_counter, 14)
+
+
+class TestUsptoSamplingContainer(PopulateQueries):
+    @classmethod
+    def setUpClass(cls):
+        if os.path.exists(DATABASE_PATH):
+            os.unlink(DATABASE_PATH)
+
+        FileCache.parse_counter = 0
+        UsptoZipCache.file_reads = 0
+        cls.uspto = uspto.Uspto(
+            td("data/April 2023 Patent Grant Bibliographic Data"),
+            sample=lambda data: True
+            if (data[0] == "path")
+            else True
+            if ("exercise" in data[1])
+            else False,
+        )
+        cls.uspto.populate(DATABASE_PATH)
+        cls.con = sqlite3.connect(DATABASE_PATH)
+        cls.cursor = cls.con.cursor()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.con.close()
+        os.unlink(DATABASE_PATH)
+
+    def test_import(
+        self,
+    ):
+        result = TestUsptoSamplingContainer.cursor.execute(
+            f"SELECT Count(*) from us_patents"
+        )
+        (count,) = result.fetchone()
+        self.assertEqual(count, 1)
+        self.assertEqual(UsptoZipCache.file_reads, 2)
+        UsptoZipCache.file_reads = 0

--- a/tests/test_file_xml_cache.py
+++ b/tests/test_file_xml_cache.py
@@ -33,6 +33,7 @@ class TestFileCache(unittest.TestCase):
     def setUpClass(self):
         # Create a new FileCache instance before each test
         self.file_cache = FileCache()
+        FileCache.parse_counter = 0
 
     def test_read_cached_data(self):
         # Test reading cached data
@@ -51,6 +52,16 @@ class TestFileCache(unittest.TestCase):
         self.assertEqual(result, self.file_cache.cached_data)
         # Assert that no parsing took place
         self.assertEqual(self.file_cache.parse_counter, 1)
+
+        self.file_cache.parse_counter = 0
+
+
+class TestFileCache(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        # Create a new FileCache instance before each test
+        self.file_cache = FileCache()
+        FileCache.parse_counter = 0
 
     def test_read_new_data(self):
         # Test reading and parsing new data
@@ -76,6 +87,16 @@ class TestFileCache(unittest.TestCase):
         # Assert that parsing took place
         self.assertEqual(FileCache.parse_counter, 2)
 
+        self.file_cache.parse_counter = 0
+
+
+class TestFileCache(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        # Create a new FileCache instance before each test
+        self.file_cache = FileCache()
+        FileCache.parse_counter = 0
+
     def test_cached_data(self):
         # Test that parse_counter increments when new data is read
         xml_chunk = "<patent><title>Test Patent</title></patent>"
@@ -92,3 +113,5 @@ class TestFileCache(unittest.TestCase):
 
         # Assert that parse_counter remains the same
         self.assertEqual(self.file_cache.parse_counter, 1)
+
+        self.file_cache.parse_counter = 0

--- a/tests/test_uspto_zip_cache.py
+++ b/tests/test_uspto_zip_cache.py
@@ -18,7 +18,6 @@
 #
 """Test of decompressing/extracting Zip files of US patent office"""
 
-import os
 import unittest
 
 from .test_dir import add_src_dir, td
@@ -27,55 +26,64 @@ add_src_dir()
 
 from alexandria3k.uspto_zip_cache import UsptoZipCache
 
-FILE_PATH = td("data/April 2023 Patent Grant Bibliographic Data")
+FILE_PATH_1 = td(
+    "data/April 2023 Patent Grant Bibliographic Data/ipgb20221025_wk43.zip"
+)
+FILE_PATH_2 = td(
+    "data/April 2023 Patent Grant Bibliographic Data/ipgb20230404_wk14.zip"
+)
 
 
-class TestUsptoZipCache(unittest.TestCase):
+class TestUsptoZipCachedRead(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        self.file_path = []
         self.file_cache = UsptoZipCache()
-
-        # Read through the directory
-        for file_name in os.listdir(FILE_PATH):
-            path = os.path.join(FILE_PATH, file_name)
-            if not os.path.isfile(path):
-                continue
-
-            self.file_path.append(path)
+        UsptoZipCache.file_reads = 0
 
     def test_read_cached_data(self):
         # Read the first zip file
-        data_1 = self.file_cache.read(self.file_path[0])
+        data_1 = self.file_cache.read(FILE_PATH_1)
         self.assertEqual(UsptoZipCache.file_reads, 1)
 
         # Read the same zip file again, data should be cached
-        data_1_cached = self.file_cache.read(self.file_path[0])
+        data_1_cached = self.file_cache.read(FILE_PATH_1)
         self.assertEqual(UsptoZipCache.file_reads, 1)
         self.assertEqual(data_1, data_1_cached)
 
+
+class TestUsptoNewRead(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.file_cache = UsptoZipCache()
+        UsptoZipCache.file_reads = 0
+
     def test_read_new_data(self):
         # Read the first zip file
-        data_2 = self.file_cache.read(self.file_path[0])
+        data_2 = self.file_cache.read(FILE_PATH_1)
         self.assertEqual(UsptoZipCache.file_reads, 1)
 
         # Read the same zip file again, data should be cached
-        data_2_cached = self.file_cache.read(self.file_path[1])
+        data_2_cached = self.file_cache.read(FILE_PATH_2)
         self.assertEqual(UsptoZipCache.file_reads, 2)
         self.assertNotEqual(data_2, data_2_cached)
+
+
+class TestUsptoExtraction(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.file_cache = UsptoZipCache()
+        UsptoZipCache.file_reads = 0
 
     def test_extracted_data(self):
         """Verify if the splitting of the contents inside the Zip
         is equal to the patents inside."""
 
         # Read the first zip file
-        data_1 = self.file_cache.read(self.file_path[0])
+        extracted_data_1 = self.file_cache.read(FILE_PATH_1)
         self.assertEqual(UsptoZipCache.file_reads, 1)
-        self.assertEqual(len(data_1), 11)
+        self.assertEqual(len(extracted_data_1), 11)
 
         # Read the second zip file
-        data_2 = self.file_cache.read(self.file_path[1])
+        extracted_data_2 = self.file_cache.read(FILE_PATH_2)
         self.assertEqual(UsptoZipCache.file_reads, 2)
-        self.assertEqual(len(data_2), 3)
-
-        UsptoZipCache.file_reads = 0
+        self.assertEqual(len(extracted_data_2), 3)


### PR DESCRIPTION
Add sampling to USPTO to control Zip file and container sampling,  defaults to `lambda n: ("True", "True")`.

 When the first variable of the callable  returns `True` the  Zip file will get processed, when it returns `False`  the container will get skipped. Similarly, when the second variable of the callable returns `True` the container will get processed,   when it returns `False` the container will get skipped.

Zip file sampling is handled in uspto.py, while container sampling is handled in uspto_zip_cache.py

Add changes to caching tests to comply with CI regulations.