### PR TITLE
Fix ambiguity on index page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,10 +15,10 @@ set <https://support.orcid.org/hc/en-us/articles/360006897394-How-do-I-get-the-p
 (25 GB compressed, 435 GB uuncompressed), containing about 78 million
 author records,
 the `US Patent and Trademark Office issued patents <https://bulkdata.uspto.gov>`__ 
-(11 GB compressed, 115 GB uncompressed), containing about 5.4 million records,
+(11 GB compressed, 115 GB uncompressed), containing about 5.4 million records from 2005 to present,
 as well as data sets of funder bodies, journal names,
 open access journals, and research organizations.
-from 2005 to present (11 GB compressed).
+
 
 The *alexandria3k*
 package installation contains all elements required to run it. It does


### PR DESCRIPTION
Fix a small sentence that slipped to the end of the intro paragraph. I added it back  to USPTO description.