### PR TITLE
Add grid table

### DIFF
--- a/tests/data_sources/test_ror.py
+++ b/tests/data_sources/test_ror.py
@@ -89,6 +89,16 @@ class TestRorPopulate(unittest.TestCase):
         self.assertTrue(("501100001779",) in rows)
         self.assertTrue(("501100006532",) in rows)
 
+    def test_grid_ids(self):
+        result = TestRorPopulate.cursor.execute(
+            """SELECT grid FROM ror_grid WHERE ror_id=(
+                    SELECT id FROM research_organizations WHERE
+                        ror_path='04j757h98')"""
+        )
+        rows = list(result)
+        self.assertEqual(len(rows), 1)
+        self.assertTrue(("grid.1019.9",) in rows)
+
     def test_ror_types(self):
         result = TestRorPopulate.cursor.execute(
             """SELECT type FROM ror_types WHERE ror_id=(


### PR DESCRIPTION
This branch adds table:**ror_grid** to the ROR database when populated. The table contains the ror_id of the organization and the corresponding grid_id (Global Research Identifier Database) for organizations with valid grid_id. The GRID identifier was discontinued in 2021, but it is included for the creation of ground truth for author affiliations. Furthermore, tests were added to ensure the intended working of the code.