### PR TITLE
Add grid identifier to ROR

### DIFF
--- a/src/alexandria3k/data_sources/ror.py
+++ b/src/alexandria3k/data_sources/ror.py
@@ -181,6 +181,7 @@ class RorDetailsTableMeta(TableMeta):
 
 
 tables = [
+    # Although deprecated, we are adding it as an additional organization identifier
     TableMeta(
         "research_organizations",
         cursor_class=RorCursor,
@@ -193,6 +194,7 @@ tables = [
             ColumnMeta(
                 "country_code", lambda row: row["country"]["country_code"]
             ),
+            ColumnMeta("grid", lambda row: row["external_ids"]["GRID"]["all"]),
         ],
     ),
     RorDetailsTableMeta(
@@ -244,7 +246,7 @@ tables = [
             ColumnMeta("postcode", lambda row: row["postcode"]),
         ],
     ),
-    # OrgRef and GRID are deprecated, so we are not supporting these fields
+    # OrgRef is deprecated, so we are not supporting this field
     RorDetailsTableMeta(
         "ror_funder_ids",
         extract_multiple=external_ids_getter("FundRef"),

--- a/tests/data_sources/test_ror.py
+++ b/tests/data_sources/test_ror.py
@@ -70,6 +70,7 @@ class TestRorPopulate(unittest.TestCase):
             status,
             established,
             country_code,
+            grid,
         ) = result.fetchone()
         self.assertEqual(id, 0)
         self.assertEqual(ror_path, "019wvm592")
@@ -77,6 +78,7 @@ class TestRorPopulate(unittest.TestCase):
         self.assertEqual(status, "active")
         self.assertEqual(established, 1946)
         self.assertEqual(country_code, "AU")
+        self.assertEqual(grid, "grid.1001.0")
 
     def test_funder_ids(self):
         result = TestRorPopulate.cursor.execute(


### PR DESCRIPTION
This branch adds **grid** as a field to the _research_organizations_ table to the ROR database when populated. The GRID identifier was deprecated in 2021, but it is included for the creation of ground truth for author affiliations. Furthermore, tests were updated to ensure the intended working of the code.