### PR TITLE
Add progress bar as debug option

### DIFF
--- a/src/alexandria3k/__main__.py
+++ b/src/alexandria3k/__main__.py
@@ -464,6 +464,7 @@ def get_cli_parser():
     populated-data: Data of the populated database;
     populated-reports: Query results from the populated database;
     progress: Report population progress;
+    progress_bar: Display a progress bar;
     sorted-tables: Topologically ordered Crossref query tables;
     stderr: Log to standard error;
 """,

--- a/src/alexandria3k/data_source.py
+++ b/src/alexandria3k/data_source.py
@@ -57,6 +57,9 @@ CONTAINER_INDEX = 1
 ROWID_INDEX = 2
 """int: database table index using the row id."""
 
+PROGRESS_BAR_LENGTH = 50
+"""int: length of the progress bar printed during database population."""
+
 
 class StreamingTable:
     """An apsw table streaming over data of the supplied table metadata"""
@@ -277,6 +280,25 @@ class FilesCursor(ItemsCursor):
         super().__init__(table)
         self.get_file_cache = get_file_cache
 
+    def debug_progress_bar(self):
+        """Print a progress bar"""
+        total_length = len(self.table.data_source)
+        current_progress = self.file_index + 1
+
+        percent = current_progress / total_length * 100
+        progress_marker = int(
+            PROGRESS_BAR_LENGTH * current_progress / total_length
+        )
+        progress_bar = "#" * progress_marker + "-" * (
+            PROGRESS_BAR_LENGTH - progress_marker
+        )
+        debug.log(
+            "progress_bar",
+            f"\r[{progress_bar}] {percent:.2f}% | "
+            f"Processed {current_progress} out of {total_length} files",
+            end="",
+        )
+
     def Filter(self, index_number, _index_name, constraint_args):
         """Always called first to initialize an iteration to the first
         (possibly constrained) row of the table"""
@@ -308,6 +330,8 @@ class FilesCursor(ItemsCursor):
         self.eof = False
         # The single file has been read. Set EOF in next Next call
         self.file_read = True
+
+        self.debug_progress_bar()
 
 
 class _IndexManager:

--- a/src/alexandria3k/debug.py
+++ b/src/alexandria3k/debug.py
@@ -70,6 +70,7 @@ def set_flags(flags):
     * sql: Executed SQL statements;
     * perf: Performance timings;
     * progress: Report population progress;
+    * progress_bar: Display a progress bar;
     * sorted-tables: Topologically ordered Crossref query tables;
     * stderr: Log to standard error;
 
@@ -93,7 +94,7 @@ def enabled(flag):
     return flag in enabled_flags
 
 
-def log(flag, message):
+def log(flag, message, flush=True, end="\n"):
     """
     Output the specified message if the corresponding flag is enabled.
 
@@ -104,4 +105,4 @@ def log(flag, message):
     :type message: str
     """
     if flag in enabled_flags:
-        print(message, file=output, flush=True)
+        print(message, file=output, flush=flush, end=end)


### PR DESCRIPTION
This pull request adds a debug option which allows a user to keep track of how far the populating of the database is. 
It will show in the terminal/command line like this: 
`[#########################-------------------------] 50.00% | Processed 1 out of 2 files`

It can be enable by the flag `-d progress_bar`