### PR TITLE
Process to disambiguate author affiliations using gpt-4

### DIFF
--- a/src/Pipfile
+++ b/src/Pipfile
@@ -7,6 +7,8 @@ name = "pypi"
 apsw = "*"
 importlib-metadata = "*"
 pyahocorasick = "*"
+openai = "*"
+levenshtein = "*"
 
 [dev-packages]
 black = "*"

--- a/src/alexandria3k/processes/distinguish_affiliations.py
+++ b/src/alexandria3k/processes/distinguish_affiliations.py
@@ -1,3 +1,21 @@
+#
+# Alexandria3k Crossref bibliographic metadata processing
+# Copyright (C) 2023-2024  Dibyendu Gupta
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
 """"This process is used to distinguish the affiliations mentioned in the crossref dataset."""
 import sys
 import time
@@ -14,7 +32,6 @@ from alexandria3k.common import (
 from alexandria3k import perf
 from alexandria3k.db_schema import ColumnMeta, TableMeta
 
-
 tables = [
     TableMeta(
         "distinct_affiliations",
@@ -28,12 +45,21 @@ tables = [
     ),
 ]
 
+GPT_PROMPT = """From the given textual piece, identify ONLY the university/research organization and
+              city mentioned. The response should be (organization, city). DO NOT produce any
+              other textual information. Ignore all other information mentioned in the textual
+              piece. If organization or city is not recognized, then return ( , )"""
+GPT_MODEL = "gpt-4-1106-preview"
+
 
 def process(database_path):
     """
-    This process is used to distinguish the affiliations mentioned in the crossref dataset. It
-    uses the GPT-4 model to extract the affiliation and city from the affiliation text and
-    match it to the ROR database based on levenshtein distance.
+    Distinguishes the affiliations mentioned in the crossref dataset. It uses the GPT-4 model to
+    extract the affiliation and city from the affiliation text and match it to the ROR database
+    based on Levenshtein distance.
+
+    The distinguished affiliations is used by link_aa_llm.py to link authors to their lowest-level
+    research organization.
 
     :param database_path: The path to the database
     """
@@ -45,14 +71,14 @@ def process(database_path):
     ensure_table_exists(database, "distinct_affiliations")
     ensure_table_exists(database, "research_organizations")
 
-    select_cursor = database.cursor()
-    select_cursor_2 = database.cursor()
-    insert_cursor = database.cursor()
+    affiliation_select_cursor = database.cursor()
+    ror_cursor = database.cursor()
+    affiliation_insert_cursor = database.cursor()
 
     distinct_affiliations_number = 0
     time_start = time.time()
     # Iterate over all the affiliations mentioned in crossref
-    for mentioned_name in select_cursor.execute(
+    for mentioned_name in affiliation_select_cursor.execute(
         """
         SELECT DISTINCT name FROM distinct_affiliations
         """
@@ -61,22 +87,16 @@ def process(database_path):
         if not mentioned_name:
             continue
         # Prompt for the GPT-4 model to extract the affiliation and city from the affiliation text
-        prompt = (
-            "From the given textual piece, identify ONLY the university/research organization and "
-            "city mentioned. The response should be (organization, city). DO NOT produce any "
-            "other textual information. Ignore all other information mentioned in the textual "
-            "piece. If organization or city is not recognized, then return ( , )"
-            + str(mentioned_name)
-        )
+        prompt = GPT_PROMPT + str(mentioned_name)
 
         completion = query_response(client, prompt)
 
         gpt_city, gpt_org = format_result(completion)
 
-        best_ror_id = find_best_ror(gpt_org, select_cursor_2)
+        best_ror_id = find_best_ror(gpt_org, ror_cursor)
         # Insert the best affiliation match into the distinct_affiliations table (if found)
         if best_ror_id != -1:
-            insert_cursor.execute(
+            affiliation_insert_cursor.execute(
                 "INSERT INTO distinct_affiliations VALUES (?, ?, ?, ?, ?)",
                 (
                     distinct_affiliations_number,
@@ -88,27 +108,27 @@ def process(database_path):
             )
         distinct_affiliations_number += 1
 
-    select_cursor.close()
-    select_cursor_2.close()
-    insert_cursor.close()
+    affiliation_select_cursor.close()
+    ror_cursor.close()
+    affiliation_insert_cursor.close()
     print(f"llm_process_valid_authors took {time.time() - time_start} seconds")
     perf.log(
         f"link_aa_llm added {distinct_affiliations_number} distinct affiliations"
     )
 
 
-def find_best_ror(gpt_org, select_cursor_2):
+def find_best_ror(gpt_org, ror_cursor):
     """
-    This function is used to find the best affiliation match based on levenshtein distance.
+    Finds the best affiliation match based on levenshtein distance.
 
     :param gpt_org: The organization name extracted from the GPT-4 model
-    :param select_cursor_2: The cursor to execute the query
+    :param ror_cursor: The cursor to execute the query
     """
     # Calculate the Levenshtein distance btw gpt_org and ror_org and choose the best match
     # (narrow the search by only comparing organizations from the same city)
     best_ror_id = -1
     best_length = sys.maxsize
-    for ror_id, ror_org in select_cursor_2.execute(
+    for ror_id, ror_org in ror_cursor.execute(
         """
                     SELECT id, name FROM research_organizations
                     """,
@@ -123,7 +143,7 @@ def find_best_ror(gpt_org, select_cursor_2):
 
 def format_result(completion):
     """
-    This function formats the result of the query response to remove brackets.
+    Formats the result of the query response to remove brackets.
 
     :param completion: The response from the GPT-4 model
     """
@@ -139,13 +159,13 @@ def format_result(completion):
 
 def query_response(client, prompt):
     """
+    Queries the GPT-4 model to extract the affiliation and city from the affiliation text. It
+    loops and resets the API if the rate limit is exceeded.
+
     The querying of the prompt is done through the OpenAI API. The limit of number and amount of
     queries depends on the users plan. This could affect the time taken to run the process. Often
     the API might need to reset due to rate limiting. It is expensive to run the process multiple
     times, so we wait for the reset and continue the process.
-
-    This function is used to query the GPT-4 model to extract the affiliation and city from the
-    affiliation text. It loops and resets the API if the rate limit is exceeded.
 
     :param client: The OpenAI client
     :param prompt: The prompt to query the GPT-4 model
@@ -153,7 +173,7 @@ def query_response(client, prompt):
     try:
         # Extract the affiliation and city from the provided textual affiliation
         completion = client.chat.completions.create(
-            model="gpt-4-1106-preview",
+            model=GPT_MODEL,
             messages=[
                 {
                     "role": "user",

--- a/src/alexandria3k/processes/distinguish_affiliations.py
+++ b/src/alexandria3k/processes/distinguish_affiliations.py
@@ -1,0 +1,172 @@
+""""This process is used to distinguish the affiliations mentioned in the crossref dataset."""
+import sys
+import time
+
+import Levenshtein
+import openai
+import apsw
+from openai import OpenAI
+from alexandria3k.common import (
+    ensure_table_exists,
+    log_sql,
+    set_fast_writing,
+)
+from alexandria3k import perf
+from alexandria3k.db_schema import ColumnMeta, TableMeta
+
+
+tables = [
+    TableMeta(
+        "distinct_affiliations",
+        columns=[
+            ColumnMeta("id"),
+            ColumnMeta("mentioned_name"),
+            ColumnMeta("gpt_name"),
+            ColumnMeta("city"),
+            ColumnMeta("ror_id"),
+        ],
+    ),
+]
+
+
+def process(database_path):
+    """
+    This process is used to distinguish the affiliations mentioned in the crossref dataset. It
+    uses the GPT-4 model to extract the affiliation and city from the affiliation text and
+    match it to the ROR database based on levenshtein distance.
+
+    :param database_path: The path to the database
+    """
+    database = apsw.Connection(database_path)
+    client = OpenAI()
+    database.execute(log_sql("DROP TABLE IF EXISTS distinct_affiliations"))
+    database.execute(log_sql(tables[0].table_schema()))
+    set_fast_writing(database)
+    ensure_table_exists(database, "distinct_affiliations")
+    ensure_table_exists(database, "research_organizations")
+
+    select_cursor = database.cursor()
+    select_cursor_2 = database.cursor()
+    insert_cursor = database.cursor()
+
+    distinct_affiliations_number = 0
+    time_start = time.time()
+    # Iterate over all the affiliations mentioned in crossref
+    for mentioned_name in select_cursor.execute(
+        """
+        SELECT DISTINCT name FROM distinct_affiliations
+        """
+    ):
+        affiliation_name = mentioned_name[0]
+        if not mentioned_name:
+            continue
+        # Prompt for the GPT-4 model to extract the affiliation and city from the affiliation text
+        prompt = (
+            "From the given textual piece, identify ONLY the university/research organization and "
+            "city mentioned. The response should be (organization, city). DO NOT produce any "
+            "other textual information. Ignore all other information mentioned in the textual "
+            "piece. If organization or city is not recognized, then return ( , )"
+            + str(mentioned_name)
+        )
+
+        completion = query_response(client, prompt)
+
+        gpt_city, gpt_org = format_result(completion)
+
+        best_ror_id = find_best_ror(gpt_org, select_cursor_2)
+        # Insert the best affiliation match into the distinct_affiliations table (if found)
+        if best_ror_id != -1:
+            insert_cursor.execute(
+                "INSERT INTO distinct_affiliations VALUES (?, ?, ?, ?, ?)",
+                (
+                    distinct_affiliations_number,
+                    affiliation_name,
+                    gpt_org,
+                    gpt_city,
+                    best_ror_id,
+                ),
+            )
+        distinct_affiliations_number += 1
+
+    select_cursor.close()
+    select_cursor_2.close()
+    insert_cursor.close()
+    print(f"llm_process_valid_authors took {time.time() - time_start} seconds")
+    perf.log(
+        f"link_aa_llm added {distinct_affiliations_number} distinct affiliations"
+    )
+
+
+def find_best_ror(gpt_org, select_cursor_2):
+    """
+    This function is used to find the best affiliation match based on levenshtein distance.
+
+    :param gpt_org: The organization name extracted from the GPT-4 model
+    :param select_cursor_2: The cursor to execute the query
+    """
+    # Calculate the Levenshtein distance btw gpt_org and ror_org and choose the best match
+    # (narrow the search by only comparing organizations from the same city)
+    best_ror_id = -1
+    best_length = sys.maxsize
+    for ror_id, ror_org in select_cursor_2.execute(
+        """
+                    SELECT id, name FROM research_organizations
+                    """,
+    ):
+        if not ror_org:
+            continue
+        if Levenshtein.distance(gpt_org, ror_org) < best_length:
+            best_length = Levenshtein.distance(gpt_org, ror_org)
+            best_ror_id = ror_id
+    return best_ror_id
+
+
+def format_result(completion):
+    """
+    This function formats the result of the query response to remove brackets.
+
+    :param completion: The response from the GPT-4 model
+    """
+    # only extract the "content" field of the response, we only consider the first affiliation
+    response = str(completion.choices[0].message.content)
+    response_split = response.split(",")
+    gpt_org = response_split[0].replace("(", "")
+    gpt_city = ""
+    if len(response_split) > 1:
+        gpt_city = response_split[1].replace(")", "")
+    return gpt_city, gpt_org
+
+
+def query_response(client, prompt):
+    """
+    The querying of the prompt is done through the OpenAI API. The limit of number and amount of
+    queries depends on the users plan. This could affect the time taken to run the process. Often
+    the API might need to reset due to rate limiting. It is expensive to run the process multiple
+    times, so we wait for the reset and continue the process.
+
+    This function is used to query the GPT-4 model to extract the affiliation and city from the
+    affiliation text. It loops and resets the API if the rate limit is exceeded.
+
+    :param client: The OpenAI client
+    :param prompt: The prompt to query the GPT-4 model
+    """
+    try:
+        # Extract the affiliation and city from the provided textual affiliation
+        completion = client.chat.completions.create(
+            model="gpt-4-1106-preview",
+            messages=[
+                {
+                    "role": "user",
+                    "content": prompt,
+                }
+            ],
+        )
+        return completion
+    except openai.RateLimitError:
+        # if the error is due to rate limiting, wait for 60 seconds
+        print("Rate limit exceeded. Waiting for reset...")
+        time.sleep(60)
+        return query_response(client, prompt)  # Retry the request
+    except openai.OpenAIError as e:
+        print(e)
+        return e

--- a/src/alexandria3k/processes/link_aa_base_ror.py
+++ b/src/alexandria3k/processes/link_aa_base_ror.py
@@ -191,7 +191,7 @@ def process(database_path):
     """
     Process the specified database creating a table that links Crossref work
     authors to their corresponding research organization as codified in the
-    Research Orgnization Registry (ROR).
+    Research Organization Registry (ROR).
     The link is made to the lowest identifiable organizational level,
     e.g. an author's clinic, school, or institute.
 

--- a/src/alexandria3k/processes/link_aa_llm.py
+++ b/src/alexandria3k/processes/link_aa_llm.py
@@ -1,0 +1,109 @@
+"""This process is to link authors with their affiliations (matched to their ror_id)."""
+import time
+
+import apsw
+from alexandria3k.common import (
+    ensure_table_exists,
+    log_sql,
+    set_fast_writing,
+)
+from alexandria3k import perf
+from alexandria3k.db_schema import ColumnMeta, TableMeta
+
+
+tables = [
+    TableMeta(
+        "distinct_author_affiliations",
+        columns=[
+            ColumnMeta("author_id"),
+            ColumnMeta("affiliation_name"),
+            ColumnMeta("gpt_name"),
+            ColumnMeta("ror_id"),
+        ],
+    ),
+    TableMeta(
+        "valid_distinct_affiliations",
+        columns=[
+            ColumnMeta("id"),
+            ColumnMeta("mentioned_name"),
+            ColumnMeta("gpt_name"),
+            ColumnMeta("city"),
+            ColumnMeta("ror_id"),
+        ],
+    ),
+]
+
+
+def process(database_path):
+    """
+    This process is used to link the authors to the lowest-level research organization identified
+    by the GPT-4 model (from distinct_affiliations table). This process is run after running the
+    distinguish_affiliations process. It creates a table of valid distinct affiliations with
+    authors from crossref and their affiliations (with gpt-4 generated name and ror_id).
+
+    :param database_path: The path to the database
+    """
+    database = apsw.Connection(database_path)
+    database.execute(
+        log_sql("DROP TABLE IF EXISTS distinct_author_affiliations")
+    )
+    database.execute(
+        log_sql("DROP TABLE IF EXISTS valid_distinct_affiliations")
+    )
+    database.execute(log_sql(tables[0].table_schema()))
+    database.execute(log_sql(tables[1].table_schema()))
+    set_fast_writing(database)
+    ensure_table_exists(database, "author_affiliations")
+    ensure_table_exists(database, "research_organizations")
+    ensure_table_exists(database, "distinct_affiliations")
+
+    insert_cursor = database.cursor()
+    select_cursor = database.cursor()
+    select_cursor_2 = database.cursor()
+    time_start = time.time()
+
+    # Create a table of valid distinct affiliations (where gpt-4 generated name is not empty)
+    # Note: whenever an organization is empty (""), distinguish_affiliations process assigns
+    # it to ror_id = 20233
+    for (
+        valid_id,
+        mentioned_name,
+        gpt_name,
+        city,
+        ror_id,
+    ) in select_cursor.execute(
+        """
+        SELECT id, mentioned_name, gpt_name, city, ror_id FROM distinct_affiliations
+        WHERE ror_id != 20233
+        """
+    ):
+        insert_cursor.execute(
+            "INSERT INTO valid_distinct_affiliations VALUES (?, ?, ?, ?, ?)",
+            (valid_id, mentioned_name, gpt_name, city, ror_id),
+        )
+
+    # Based on affiliation mentioned in crossref, link the author to their affiliations
+    for (
+        author_id,
+        author_affiliation_name,
+        gpt_name,
+        ror_id,
+    ) in select_cursor.execute(
+        """
+        SELECT aa.author_id, aa.name, vda.gpt_name, vda.ror_id  FROM author_affiliations aa
+        JOIN valid_distinct_affiliations vda ON aa.name = vda.mentioned_name
+        """
+    ):
+        insert_cursor.execute(
+            "INSERT INTO distinct_author_affiliations VALUES (?, ?, ?, ?)",
+            (author_id, author_affiliation_name, gpt_name, ror_id),
+        )
+
+    select_cursor.close()
+    select_cursor_2.close()
+    insert_cursor.close()
+    time_end = time.time()
+    print(f"link-aa-llm took {time_end - time_start} seconds")
+    perf.log(
+        "link-aa-llm has completed linking authors to gpt identified affiliations"
+    )

--- a/src/alexandria3k/processes/link_aa_llm.py
+++ b/src/alexandria3k/processes/link_aa_llm.py
@@ -1,3 +1,21 @@
+#
+# Alexandria3k Crossref bibliographic metadata processing
+# Copyright (C) 2023-2024  Dibyendu Gupta
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
 """This process is to link authors with their affiliations (matched to their ror_id)."""
 import time
 
@@ -33,13 +51,20 @@ tables = [
     ),
 ]
 
+# Note: whenever an organization is empty (""), distinguish_affiliations process assigns
+# it to ror_id = 20233. The reason is ror_id (20233) is a research organization named "2B".
+# So, Levenshtein distance assigns it 20233 as it is the shortest distance.
+INVALID_ROR_ID = 20233
+
 
 def process(database_path):
     """
-    This process is used to link the authors to the lowest-level research organization identified
-    by the GPT-4 model (from distinct_affiliations table). This process is run after running the
-    distinguish_affiliations process. It creates a table of valid distinct affiliations with
-    authors from crossref and their affiliations (with gpt-4 generated name and ror_id).
+    Process the specified database creating a table that links Crossref work authors to their
+    corresponding research organization as codified in the Research Organization Registry (ROR)
+    using distinguished affiliations by a LLM.
+
+    The link is made to the lowest identifiable organizational level,
+    e.g. an author's clinic, school, or institute.
 
     :param database_path: The path to the database
     """
@@ -59,12 +84,9 @@ def process(database_path):
 
     insert_cursor = database.cursor()
     select_cursor = database.cursor()
-    select_cursor_2 = database.cursor()
     time_start = time.time()
 
     # Create a table of valid distinct affiliations (where gpt-4 generated name is not empty)
-    # Note: whenever an organization is empty (""), distinguish_affiliations process assigns
-    # it to ror_id = 20233
     for (
         valid_id,
         mentioned_name,
@@ -74,8 +96,9 @@ def process(database_path):
     ) in select_cursor.execute(
         """
         SELECT id, mentioned_name, gpt_name, city, ror_id FROM distinct_affiliations
-        WHERE ror_id != 20233
-        """
+        WHERE ror_id != ?
+        """,
+        (INVALID_ROR_ID,),
     ):
         insert_cursor.execute(
             "INSERT INTO valid_distinct_affiliations VALUES (?, ?, ?, ?, ?)",
@@ -100,7 +123,6 @@ def process(database_path):
         )
 
     select_cursor.close()
-    select_cursor_2.close()
     insert_cursor.close()
     time_end = time.time()
     print(f"link-aa-llm took {time_end - time_start} seconds")


### PR DESCRIPTION
This process adds a different dimension to author affiliation disambiguation. It uses NLP to extract affiliations from text. This process produces better results than the currently implemented matching strategy. It has a matching rate of 81.24% as compared to 36.73% of the currently implemented algorithm. It also performs much better to match authors to multiple affiliations. This process adds value to the project as it helps researchers with more accurate affiliation results.