### PR TITLE
Add progress bar to uspto.py

### DIFF
--- a/src/alexandria3k/data_sources/uspto.py
+++ b/src/alexandria3k/data_sources/uspto.py
@@ -27,6 +27,7 @@ from alexandria3k.data_source import (
     ROWID_INDEX,
     DataSource,
     ItemsCursor,
+    FilesCursor,
     StreamingCachedContainerTable,
 )
 from alexandria3k.db_schema import ColumnMeta, TableMeta
@@ -304,6 +305,14 @@ class PatentsFilesCursor(ItemsCursor):
             self.xml_contents[self.container_id], self.container_id
         )
         self.eof = False
+
+        # Update progress by reusing FilesCursor.debug_progress_bar
+        FilesCursor.debug_progress_bar(
+            self,
+            current_progress=self.container_id + 1,
+            total_length=len(self.xml_contents),
+        )
+
         # The single container has been read. Set EOF in next Next call.
         self.file_read = True
 


### PR DESCRIPTION
Closes #53 

# Add progress bar to USPTO processing

The changes ensure that as the `Next` method iterates over the XML contents, developers can visually monitor the progress of processing.

## Key Changes

- **Progress Bar Integration:**  
  The `debug_progress_bar` method from `FilesCursor` is now called within the `Next` method. This call updates the progress bar by:
  - Incrementing the current progress using `self.container_id + 1`.
  - Setting the total length of the progress based on the number of XML contents (`len(self.xml_contents)`).

- **Code Reuse:**  
  By reusing `FilesCursor.debug_progress_bar`, we maintain consistency in progress reporting across different parts of the system and reduce duplicate code.

![image](https://github.com/user-attachments/assets/4ab6e49f-6df5-4e26-a7b2-efd870b11b13)

