### PR TITLE
Add shell completion support

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -6,3 +6,148 @@ The *a3k* command can be invoked from the shell as follows.
 .. argparse::
    :ref: alexandria3k.__main__.get_cli_parser
    :prog: a3k
+
+.. _shell-completion:
+
+Shell completion
+======================
+
+The command line interface provides optional TAB completion (Bash, Zsh, Tcsh)
+implemented in :mod:`alexandria3k.completion` via the optional dependency
+`shtab <https://pypi.org/project/shtab/>`_.  When enabled it completes:
+
+* Global options (``--debug``, ``--progress``, ``--version``)
+* Subcommands (``populate``, ``query``, ``process``, ``download``,
+  ``list-sources``, ``list-processes``, schema listing commands, ...)
+* Data source names (``populate``, ``query``, ``download``)
+* Process names (``process`` subcommand argument)
+* Facility names (``list-source-schema`` / ``list-process-schema``)
+* File / path arguments (``--query-file``, ``--row-selection-file``,
+  ``--output``, positional ``data_location``, ``--attach-databases``)
+
+Enabling
+~~~~~~~~
+
+Install with the extra (recommended):
+
+.. code-block:: bash
+
+    pip install 'alexandria3k[completion]'
+
+Or install the dependency directly:
+
+.. code-block:: bash
+
+    pip install shtab
+
+If ``--print-completion`` exits with an instruction to install the extra,
+add it (or reinstall) and retry.
+
+Generating a script
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+    a3k --print-completion SHELL   # SHELL = bash | zsh | tcsh
+
+Bash
+^^^^
+
+System-wide (root):
+
+.. code-block:: bash
+
+    a3k --print-completion bash | sudo tee /etc/bash_completion.d/a3k > /dev/null
+
+Per-user:
+
+.. code-block:: bash
+
+    mkdir -p ~/.local/share/bash-completion/completions
+    a3k --print-completion bash > ~/.local/share/bash-completion/completions/a3k
+    # Activate in the current shell (optional)
+    source ~/.local/share/bash-completion/completions/a3k
+
+Zsh
+^^^
+
+Ensure completion is initialized (normally already in ``~/.zshrc``):
+
+.. code-block:: bash
+
+    autoload -U compinit && compinit
+
+Install function (Zsh expects leading underscore):
+
+.. code-block:: bash
+
+    a3k --print-completion zsh > "${fpath[1]}/_a3k"
+
+If ``${fpath[1]}`` is not writable:
+
+.. code-block:: bash
+
+    mkdir -p ~/.zsh/completions
+    a3k --print-completion zsh > ~/.zsh/completions/_a3k
+    fpath=(~/.zsh/completions $fpath)
+    autoload -U compinit && compinit
+
+Tcsh
+^^^^
+
+.. code-block:: csh
+
+    a3k --print-completion tcsh > ~/.a3k_completions.csh
+    echo 'source ~/.a3k_completions.csh' >> ~/.tcshrc
+    source ~/.a3k_completions.csh
+
+Usage examples
+~~~~~~~~~~~~~~
+
+.. code-block:: console
+
+    $ a3k popu<TAB>
+    populate
+    $ a3k populate db.sqlite <TAB>
+    crossref-metadata datacite ...
+    $ a3k process <TAB>
+    link-works-asjcs ...
+    $ a3k query -Q <TAB>
+    (file suggestions...)
+
+Regenerating after upgrades
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Re-run ``a3k --print-completion <shell>`` after upgrading if new data sources
+or processes appear, overwriting the existing completion file.
+
+Troubleshooting
+~~~~~~~~~~~~~~~
+
+===============================  =============================================================
+Symptom                          Resolution
+===============================  =============================================================
+``--print-completion`` errors    ``pip install 'alexandria3k[completion]'``
+Data sources not completing      Regenerate script; ensure new file was sourced
+Zsh: no completion for ``a3k``   Confirm ``_a3k`` is on ``$fpath`` before ``compinit`` runs
+Bash: script has no effect       Ensure system ``bash-completion`` installed; open new shell
+===============================  =============================================================
+
+Removing completion
+~~~~~~~~~~~~~~~~~~~
+
+Delete the installed file(s) and start a new shell:
+
+* Bash system-wide: ``sudo rm /etc/bash_completion.d/a3k``
+* Bash user: ``rm ~/.local/share/bash-completion/completions/a3k``
+* Zsh: remove ``_a3k``; rerun ``compinit -u`` or restart shell
+* Tcsh: remove the file and its ``source`` line from ``~/.tcshrc``
+
+Implementation notes
+~~~~~~~~~~~~~~~~~~~~
+
+``completion.py`` adds ``--print-completion``. When ``shtab`` is present the
+dynamic lists (data sources, processes, facilities) and file/path arguments are
+annotated by assigning ``action.complete`` with either a dict of choices or a
+file completion helper. If the dependency is missing a stub action prints
+instructions and exits.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,12 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
+[project.optional-dependencies]
+# This defines the extras group:
+completion = [
+    "shtab>=1.6",
+]
+
 [project.urls]
 "Homepage" = "https://github.com/dspinellis/alexandria3k"
 "Repository" = "https://github.com/dspinellis/alexandria3k.git"

--- a/src/alexandria3k/__main__.py
+++ b/src/alexandria3k/__main__.py
@@ -33,6 +33,13 @@ from alexandria3k.common import Alexandria3kError, program_version
 from alexandria3k import debug
 from alexandria3k.data_sources_lib.crossref_file_cache import FileCache
 from alexandria3k import perf
+from alexandria3k.completion import (
+    add_completion_support,
+)  # Completion integration
+from alexandria3k.facilities import (
+    facility_names,
+    facility_modules,
+)  # Moved out to avoid cycles
 
 DESCRIPTION = "a3k: Relational interface to publication metadata"
 
@@ -60,19 +67,7 @@ def class_name(facility):
     return "".join(x.title() for x in components)
 
 
-def facility_modules(facility):
-    """Return a list with the module names of the available facilities"""
-    main_dir = os.path.dirname(os.path.realpath(__file__))
-    python_files = os.listdir(f"{main_dir}/{facility}")
-    # Remove trailing .py
-    return [os.path.splitext(f)[0] for f in python_files if f.endswith(".py")]
-
-
-def facility_names(facility):
-    """Return a list with the names of the available facilities.
-    (data_source or process)"""
-    # Replace _ with -
-    return [s.replace("_", "-") for s in facility_modules(facility)]
+# facility_modules/facility_names now live in alexandria3k.facilities
 
 
 def get_data_source_instance(args):
@@ -591,6 +586,10 @@ def get_cli_parser():
     add_subcommand_list_sources(subparsers)
     add_subcommand_version(subparsers)
     add_subcommand_download(subparsers)
+
+    # Add (optional) shell completion support (no-op if shtab missing)
+    add_completion_support(parser)
+
     return parser
 
 

--- a/src/alexandria3k/completion.py
+++ b/src/alexandria3k/completion.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+#
+# Alexandria3k Crossref bibliographic metadata processing
+# Copyright (C) 2022  Diomidis Spinellis
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Provides:
+  --print-completion <bash|zsh|tcsh>
+and dynamic completions for:
+  - data_name (populate, query, download)
+  - process (process subcommand)
+  - facility positional arguments (list-source-schema, list-process-schema)
+  - file / path arguments (--query-file, --row-selection-file,
+                           --output, data_location, --attach-databases)
+"""
+import argparse
+import sys
+from typing import Any, Optional
+
+try:
+    import shtab  # type: ignore
+except ImportError:  # pragma: no cover
+    shtab = None
+
+from alexandria3k.facilities import facility_names
+
+
+class _MissingCompletionAction(argparse.Action):
+    """Fallback action when shtab isn't installed."""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        print(
+            "Install alexandria3k[completion] (adds 'shtab') for completion support.",
+            file=sys.stderr,
+        )
+        parser.exit(1)
+
+
+def _iter_subparsers(root_parser):
+    """Yield (name, parser) for each subparser in *root_parser*.
+
+    Accesses protected attributes of argparse objects; this is intentional
+    and safe for building completion metadata.
+    """
+    for action in root_parser._actions:  # pylint: disable=protected-access
+        if isinstance(
+            action,
+            argparse._SubParsersAction,  # pylint: disable=protected-access
+        ):  # pylint: disable=protected-access
+            for sp_name, sp in action.choices.items():
+                yield sp_name, sp
+
+
+def _attach_positional_completions(
+    parser: argparse.ArgumentParser,
+) -> None:  # pylint: disable=protected-access
+    data_source_names = facility_names("data_sources")
+    process_names = facility_names("processes")
+    for sp_name, sp in _iter_subparsers(parser):
+        for action in sp._actions:  # pylint: disable=protected-access
+            if (
+                sp_name in {"populate", "query", "download"}
+                and action.dest == "data_name"
+            ):
+                action.complete = {"choices": data_source_names}
+            if sp_name == "process" and action.dest == "process":
+                action.complete = {"choices": process_names}
+            if sp_name == "list-source-schema" and action.dest == "facility":
+                action.complete = {"choices": data_source_names}
+            if sp_name == "list-process-schema" and action.dest == "facility":
+                action.complete = {"choices": process_names}
+
+
+def _attach_file_option_completions(
+    parser: argparse.ArgumentParser,
+) -> None:  # pylint: disable=protected-access
+    file_option_dests = {"row_selection_file", "query_file", "output"}
+    for _, sp in _iter_subparsers(parser):
+        for action in sp._actions:  # pylint: disable=protected-access
+            if action.dest in file_option_dests:
+                action.complete = shtab.FILE
+
+
+def _attach_data_location_completions(
+    parser: argparse.ArgumentParser,
+) -> None:  # pylint: disable=protected-access
+    for sp_name, sp in _iter_subparsers(parser):
+        if sp_name in {"populate", "query", "download"}:
+            for action in sp._actions:  # pylint: disable=protected-access
+                if action.dest == "data_location":
+                    action.complete = (
+                        shtab.FILE
+                    )  # If mostly dirs, change to shtab.DIR
+
+
+def _attach_attach_databases_completions(
+    parser: argparse.ArgumentParser,
+) -> None:  # pylint: disable=protected-access
+    for _sp_name, sp in _iter_subparsers(parser):
+        for action in sp._actions:  # pylint: disable=protected-access
+            if action.dest == "attach_databases":
+                action.complete = shtab.FILE
+
+
+def _attach_dynamic_completions(parser: argparse.ArgumentParser) -> None:
+    """Attach project-specific completion metadata to parser actions.
+
+    This function delegates to smaller helpers to keep complexity low for
+    linting and readability.
+    """
+    _attach_positional_completions(parser)
+    _attach_file_option_completions(parser)
+    _attach_data_location_completions(parser)
+    _attach_attach_databases_completions(parser)
+
+
+def add_completion_support(
+    parser: argparse.ArgumentParser, subparsers: Optional[Any] = None
+) -> argparse.ArgumentParser:
+    """
+    Add (or stub) shell completion support to the top-level parser.
+    Also attach dynamic completions if shtab is installed.
+    """
+    if shtab:
+        shtab.add_argument_to(parser)  # Adds --print-completion
+        if subparsers is not None and hasattr(subparsers, "choices"):
+
+            data_source_names = facility_names("data_sources")
+            process_names = facility_names("processes")
+            file_like_dests = {
+                "row_selection_file",
+                "query_file",
+                "output",
+                "data_location",
+                "attach_databases",
+            }
+            for sp_name, sp in subparsers.choices.items():  # type: ignore[attr-defined]
+                for action in sp._actions:  # pylint: disable=protected-access
+                    if (
+                        sp_name in {"populate", "query", "download"}
+                        and action.dest == "data_name"
+                    ):
+                        action.complete = {"choices": data_source_names}
+                    elif sp_name == "process" and action.dest == "process":
+                        action.complete = {"choices": process_names}
+                    elif (
+                        sp_name == "list-source-schema"
+                        and action.dest == "facility"
+                    ):
+                        action.complete = {"choices": data_source_names}
+                    elif (
+                        sp_name == "list-process-schema"
+                        and action.dest == "facility"
+                    ):
+                        action.complete = {"choices": process_names}
+                    elif action.dest in file_like_dests:
+                        action.complete = shtab.FILE
+        else:
+            _attach_dynamic_completions(parser)
+    else:
+        parser.add_argument(
+            "--print-completion",
+            choices=["bash", "zsh", "tcsh"],
+            action=_MissingCompletionAction,
+            help="print shell completion script (install alexandria3k[completion])",
+        )
+    return parser

--- a/src/alexandria3k/facilities.py
+++ b/src/alexandria3k/facilities.py
@@ -1,0 +1,46 @@
+#
+# Alexandria3k Crossref bibliographic metadata processing
+# Copyright (C) 2022-2023  Diomidis Spinellis
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Utilities for discovering available facilities (data sources, processes).
+
+Separated out to avoid cyclic imports between the CLI (``__main__``) and
+completion support. Only lightweight filesystem inspection lives here.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import List
+
+
+def facility_modules(facility: str) -> List[str]:
+    """Return a list with the module names of the available *facility*.
+
+    Examples: facility='data_sources' or 'processes'.
+    """
+    main_dir = os.path.dirname(os.path.realpath(__file__))
+    python_files = os.listdir(f"{main_dir}/{facility}")
+    return [os.path.splitext(f)[0] for f in python_files if f.endswith(".py")]
+
+
+def facility_names(facility: str) -> List[str]:
+    """Return user-visible facility names by converting underscores to dashes."""
+    return [s.replace("_", "-") for s in facility_modules(facility)]
+
+
+__all__ = ["facility_modules", "facility_names"]

--- a/tests/test_completion_facilities.py
+++ b/tests/test_completion_facilities.py
@@ -1,0 +1,62 @@
+#
+# Alexandria3k completion & facilities tests
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+"""Tests for completion integration and facilities discovery.
+
+These focus on:
+- facilities.facility_names / facility_modules returning non-empty for known groups.
+- add_completion_support augmenting a parser without raising exceptions.
+- Generated parser exposing --print-completion when shtab is installed (best-effort: optional dependency).
+"""
+import argparse
+import importlib
+import os
+import sys
+import unittest
+
+# Place project src on sys.path early (mirrors add_src_dir behavior)
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from alexandria3k.facilities import facility_names, facility_modules  # type: ignore
+from alexandria3k.completion import add_completion_support  # type: ignore
+
+
+class TestFacilities(unittest.TestCase):
+    def test_facility_modules_non_empty(self):
+        # Expect at least one data source and one process module
+        ds_mods = facility_modules("data_sources")
+        proc_mods = facility_modules("processes")
+        self.assertTrue(ds_mods, "data_sources modules list is empty")
+        self.assertTrue(proc_mods, "processes modules list is empty")
+
+    def test_facility_names_dash_conversion(self):
+        # Names should be derived from modules with _ replaced by -
+        mods = facility_modules("data_sources")
+        names = facility_names("data_sources")
+        self.assertEqual(sorted(n.replace('-', '_') for n in names), sorted(mods))
+
+
+class TestCompletion(unittest.TestCase):
+    def _build_parser(self):
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers(dest="command")
+        # Minimal fake subcommand to ensure subparsers exist
+        subparsers.add_parser("dummy", help="dummy subcommand")
+        add_completion_support(parser, subparsers)
+        return parser
+
+    def test_add_completion_support_no_error(self):
+        parser = self._build_parser()
+        # Ensure --print-completion option exists or was stubbed
+        opts = {a.option_strings[0] for a in parser._actions if a.option_strings}  # pylint: disable=protected-access
+        self.assertIn("--print-completion", opts)
+
+    def test_completion_module_importable(self):
+        # Import path should not trigger cyclic import errors
+        mod = importlib.import_module("alexandria3k.completion")
+        self.assertTrue(hasattr(mod, "add_completion_support"))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Overview
This PR closes #52  and adds **shell completion support** to the `alexandria3k` CLI using the optional [`shtab`](https://pypi.org/project/shtab/) dependency.  

Completions are provided for:
- Global options (`--debug`, `--progress`, `--version`)
- Subcommands (`populate`, `query`, `process`, `download`, etc.)
- Data source names
- Process names
- Schema facilities
- File and path arguments

## Installation
Install with the recommended extra:
```bash
pip install 'alexandria3k[completion]'
```

Or install the dependency directly:
~~~bash
pip install shtab
~~~

## Usage
Generate a completion script:
~~~bash
a3k --print-completion SHELL   # SHELL = bash | zsh | tcsh
~~~

### Example
~~~console
$ a3k popu<TAB>
populate
$ a3k query -Q <TAB>
(file suggestions…)
~~~

## Notes
- Completions work for Bash, Zsh, and Tcsh.
- If `shtab` is missing, a helpful instruction is shown.
- Re-run `a3k --print-completion <shell>` after upgrading to refresh completions.
