### PR TITLE
perf: use set instead of list in keep_unique_entries()

### DIFF
--- a/src/alexandria3k/processes/link_aa_base_ror.py
+++ b/src/alexandria3k/processes/link_aa_base_ror.py
@@ -57,11 +57,11 @@ def keep_unique_entries(automaton):
     For example, if the input is ["Ministry of Foreign Affairs", "ai"],
     remove the "ai" entry.
     """
-    to_remove = []
+    to_remove = set()
     for name in automaton:
         for _, (_, _, match) in automaton.iter(name):
             if match != name:
-                to_remove.append(match)
+                to_remove.add(match)
 
     # Remove entries in a separate step to avoid damaging the iterator
     for non_unique in to_remove:


### PR DESCRIPTION
The keep_unique_entries() function collected words to remove from the automaton in a list, which can contain duplicates when a short word appears as a substring in multiple organization names.

While remove_word() handles duplicates silently (returns False), using a set eliminates redundant remove_word() calls, improving performance on large ROR datasets with many organization names and aliases.