### PR TITLE
feat: add author blocking for disambiguation pipeline

### DIFF
--- a/src/alexandria3k/processes/link_aa_author_block.py
+++ b/src/alexandria3k/processes/link_aa_author_block.py
@@ -1,0 +1,99 @@
+#
+# Alexandria3k Crossref bibliographic metadata processing
+# Copyright (C) 2022-2026  Diomidis Spinellis
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Author blocking for disambiguation based on first name initial and family name."""
+
+import re
+import unicodedata
+from typing import Optional
+
+import apsw
+
+from alexandria3k import perf
+from alexandria3k.common import ensure_table_exists
+
+
+def make_blocking_key(given: Optional[str], family: Optional[str]):
+    """
+    Return a blocking key for an author based on their first name
+    initial and normalized family name.
+    Returns None if family name is missing.
+    """
+    # Skip if family name is missing
+    if not family:
+        return None
+
+    # Normalize family name: lowercase, strip diacritics, strip punctuation
+    family_normalized = unicodedata.normalize("NFD", family.lower())
+    family_normalized = "".join(
+        c for c in family_normalized if unicodedata.category(c) != "Mn"
+    )
+    # Normalize Unicode hyphen variants to ASCII hyphen before replacement
+    family_normalized = family_normalized.replace("\u2010", "-")
+    family_normalized = family_normalized.replace("\u2013", "-")
+    family_normalized = family_normalized.replace("\u2014", "-")
+    family_normalized = family_normalized.replace("-", " ")
+    family_normalized = re.sub(r"[^\w\s]", "", family_normalized)
+    family_normalized = family_normalized.strip()
+
+    # If given name is missing, use family name alone
+    if not given:
+        return family_normalized
+
+    # Normalize given name and extract first alphabetic character
+    given_normalized = unicodedata.normalize("NFD", given.lower())
+    initial = next((c for c in given_normalized if c.isalpha()), None)
+
+    if not initial:
+        return family_normalized
+
+    return f"{initial}.{family_normalized}"
+
+
+def blocking(database_path: str):
+    """
+    Build blocking dictionary from work_authors table.
+    Returns a dictionary mapping blocking keys to lists of
+    (author_id, work_id) paper-level mentions.
+    """
+    database = apsw.Connection(database_path)
+    ensure_table_exists(database, "work_authors")
+    select_cursor = database.cursor()
+
+    blocks = {}
+    for author_id, given, family, work_id in select_cursor.execute(
+        "SELECT id, given, family, work_id FROM work_authors"
+    ):
+        key = make_blocking_key(given, family)
+        if key is None:
+            continue
+        if key not in blocks:
+            blocks[key] = []
+        blocks[key].append((author_id, work_id))
+
+    select_cursor.close()
+    perf.log(f"blocking built {len(blocks)} blocks")
+    return blocks
+
+
+def process(database_path: str):
+    """
+    Process the specified database building author blocks
+    for disambiguation.
+    """
+    return blocking(database_path)

--- a/tests/processes/test_link_aa_author_block.py
+++ b/tests/processes/test_link_aa_author_block.py
@@ -1,0 +1,166 @@
+#
+# Alexandria3k Crossref bibliographic metadata processing
+# Copyright (C) 2026  Diomidis Spinellis
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Tests for author blocking"""
+from alexandria3k.processes.link_aa_author_block import (
+    make_blocking_key,
+    blocking,
+)
+import os
+import unittest
+import apsw
+
+from ..test_dir import add_src_dir, td
+add_src_dir()
+
+
+
+DATABASE_PATH = td("tmp/author_blocks.db")
+
+
+class TestMakeBlockingKey(unittest.TestCase):
+    # No database needed here
+    # Each test calls make_blocking_key() directly with known inputs
+    # and asserts the output matches what we expect
+
+    def test_normal(self):
+        # Input: normal first name and family name
+        # Expected output: first initial + normalized family name
+        self.assertEqual(make_blocking_key("John", "Smith"), "j.smith")
+
+    def test_diacritics(self):
+        # Input: name with accented characters
+        # Expected output: diacritics stripped, normalized key
+        self.assertEqual(make_blocking_key("José", "Müller"), "j.muller")
+
+    def test_hyphenated_family(self):
+        # Input: hyphenated family name
+        # Expected output: hyphen replaced with space
+        self.assertEqual(
+            make_blocking_key("Mary", "Smith-Jones"), "m.smith jones"
+        )
+    def test_unicode_hyphen_family(self):
+        # Unicode non-breaking hyphen should normalize same as ASCII hyphen
+        # Bouça‐Machado with Unicode hyphen U+2010 should give same key as
+        # Bouça-Machado with ASCII hyphen
+        self.assertEqual(
+            make_blocking_key("Raquel", "Bou\u00e7a\u2010Machado"),"r.bouca machado"
+        )
+    def test_none_given(self):
+        # Input: given name is None
+        # Expected output: family name alone used as key
+        self.assertEqual(make_blocking_key(None, "Smith"), "smith")
+
+    def test_none_family(self):
+        # Input: family name is None
+        # Expected output: None, record should be skipped
+        self.assertIsNone(make_blocking_key("John", None))
+
+    def test_empty_family(self):
+        # Input: family name is empty string
+        # Expected output: None, record should be skipped
+        self.assertIsNone(make_blocking_key("John", ""))
+
+    def test_given_no_alpha(self):
+        # Input: given name has no alphabetic characters e.g. "123"
+        # Expected output: family name alone used as key
+        self.assertEqual(make_blocking_key("123", "Smith"), "smith")
+
+
+class TestBlocking(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        # setUpClass runs once before all tests in this class
+        # Input: nothing
+        # Output: a fresh database at DATABASE_PATH with work_authors table
+
+        if os.path.exists(DATABASE_PATH):
+            os.unlink(DATABASE_PATH)
+        # apsw.Connection creates a new SQLite database at the given path
+        # Input: file path string
+        # Output: database connection object
+        cls.con = apsw.Connection(DATABASE_PATH)
+        cls.cursor = cls.con.cursor()
+
+        # Create work_authors table manually
+        # We only need the columns our blocking function queries
+        # Input: SQL string
+        # Output: table created in database
+        cls.cursor.execute("""
+            CREATE TABLE work_authors (
+                id INTEGER,
+                work_id INTEGER,
+                given TEXT,
+                family TEXT
+            )
+        """)
+
+        # Insert test rows
+        # Each row is one paper-level mention: (author_id, work_id, given, family)
+        cls.cursor.execute("""
+            INSERT INTO work_authors VALUES
+            (1, 101, 'John', 'Smith'),
+            (2, 102, 'James', 'Smith'),
+            (3, 103, 'John', 'Doe'),
+            (4, 104, NULL, 'Brown'),
+            (5, 105, 'José', 'Müller')
+        """)
+
+    @classmethod
+    def tearDownClass(cls):
+        # tearDownClass runs once after all tests in this class
+        # Closes connection and deletes the temp database
+        cls.con.close()
+        os.unlink(DATABASE_PATH)
+
+    def test_block_count(self):
+        # Input: database path
+        # Output: dictionary of blocks
+        # Assert: correct number of unique blocking keys created
+        blocks = blocking(DATABASE_PATH)
+        # j.smith, j.doe, brown, j.muller = 4 blocks
+        self.assertEqual(len(blocks), 4)
+
+    def test_smith_block(self):
+        # Input: database path
+        # Output: dictionary of blocks
+        # Assert: both John Smith and James Smith land in same block
+        blocks = blocking(DATABASE_PATH)
+        self.assertIn("j.smith", blocks)
+        self.assertEqual(len(blocks["j.smith"]), 2)
+
+    def test_mention_tuples(self):
+        # Assert: each mention is stored as (author_id, work_id) tuple
+        blocks = blocking(DATABASE_PATH)
+        self.assertIn((1, 101), blocks["j.smith"])
+        self.assertIn((2, 102), blocks["j.smith"])
+
+    def test_null_given_name(self):
+        # Assert: author with NULL given name uses family name as key
+        blocks = blocking(DATABASE_PATH)
+        self.assertIn("brown", blocks)
+
+    def test_diacritics_normalized(self):
+        # Assert: José Müller normalized correctly to j.muller
+        blocks = blocking(DATABASE_PATH)
+        self.assertIn("j.muller", blocks)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR implements the blocking stage of the author disambiguation pipeline for Alexandria3k.

What this does

Authors are represented as paper-level mentions (author_id, work_id) and grouped into blocks by normalized first name initial and family name. The blocking function reads from the work_authors table and returns a dictionary mapping blocking keys to lists of mentions.
Complete envisaged disambiguation process
This blocking module is the first stage of a larger author disambiguation pipeline:

Blocking (this PR): authors are grouped into candidate blocks by normalized name key, reducing the comparison space from O(n^2) across all authors to comparisons within blocks only.

Probabilistic clustering: within each block, mention pairs are scored across five dimensions - name similarity using Jaro-Winkler, affiliation token overlap using Jaccard similarity, co-author overlap, venue coherence, and temporal constraints. Scores are combined as a weighted sum.

Cluster assignment: mention pairs scoring above an upper threshold are merged into the same cluster, pairs below a lower threshold are marked as different, and ambiguous pairs are placed in an unknown cluster to avoid false positive merges.

Cluster profiles: each cluster maintains an averaged feature vector of its members, enabling O(n) incremental updates rather than O(n^2) pairwise comparisons.

Output: results are written to an author_clusters table with stable cluster IDs, confidence scores, merge provenance, and unknown class handling for auditability.

Affiliation disambiguation follows as a parallel task using country-aware token blocking and organization token overlap.