### PR TITLE
Improving Deterministic Sampling

### DIFF
--- a/src/alexandria3k/data_source.py
+++ b/src/alexandria3k/data_source.py
@@ -1146,16 +1146,16 @@ class DataFiles:
         # Collect the names of all available data files
         self.data_files = []
         counter = 1
-        for file_name in os.listdir(directory):
+        for file_name in sorted(os.listdir(directory)):
             path = os.path.join(directory, file_name)
             if not os.path.isfile(path):
-                continue
-            if not sample_container(path):
                 continue
             if file_extension and not path.endswith(file_extension):
                 # MacOS creates a .DS_Store file by default
                 continue
             if file_name_regex and not re.match(file_name_regex, file_name):
+                continue
+            if not sample_container(path):
                 continue
             counter += 1
             self.data_files.append(path)


### PR DESCRIPTION
In case of running ex: --sample 'random.random() < 0.01' there were two sources of non determinism that broke reproducible sampling even when random.seed("alexandria3k") was set

Made the following changes as fix:
1. Changed os.listdir() to sorted(os.listdir()) so directory iteration order is identical everywhere
2. Moved sample_container(path) to after the extension and regex checks so only confirmed data files ever consume an RNG draw


